### PR TITLE
Fix ambiguous use of p.AddImport

### DIFF
--- a/plugin/imports.go
+++ b/plugin/imports.go
@@ -183,7 +183,7 @@ func (p *Plugin) objectNamed(name string) generator.Object {
 	obj := p.ObjectNamed(name)
 
 	if !p.isLocal(obj) {
-		p.AddImport(string(obj.GoImportPath())).Use()
+		p.pluginImports.AddImport(string(obj.GoImportPath())).Use()
 	}
 
 	return obj


### PR DESCRIPTION
I'm seeing an error trying to install this package
```
github.com/infobloxopen/protoc-gen-atlas-validate@v0.4.1/plugin/imports.go:186:4: ambiguous selector p.AddImport
```
